### PR TITLE
fix string encoding not encoding & and ? properly

### DIFF
--- a/JBWhatsAppActivity/JBWhatsAppActivity.m
+++ b/JBWhatsAppActivity/JBWhatsAppActivity.m
@@ -126,11 +126,13 @@
     return [self stringByEncodingString:_text];
 }
 
-- (NSString *)abid {
+- (NSString *)abid
+{
     return [self stringByEncodingString:_abid];
 }
 
-- (NSString *)stringByEncodingString:(NSString *)string {
+- (NSString *)stringByEncodingString:(NSString *)string
+{
     CFStringRef encodedString = CFURLCreateStringByAddingPercentEscapes(NULL, (CFStringRef)string, NULL,
                                                                         (CFStringRef)@"!*'();:@&=+$,/?%#[]", kCFStringEncodingUTF8);
     return CFBridgingRelease(encodedString);

--- a/JBWhatsAppActivity/JBWhatsAppActivity.m
+++ b/JBWhatsAppActivity/JBWhatsAppActivity.m
@@ -60,7 +60,7 @@
         }
     }
     
-    return [NSURL URLWithString:[url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    return [NSURL URLWithString:url];
 }
 
 - (BOOL)canPerformWithActivityItems:(NSArray *)activityItems
@@ -99,6 +99,8 @@
 #pragma mark - WhatsAppMessage Class
 
 @implementation WhatsAppMessage
+@synthesize text = _text;
+@synthesize abid = _abid;
 
 - (id)init
 {
@@ -117,6 +119,21 @@
     }
     
     return self;
+}
+
+- (NSString *)text
+{
+    return [self stringByEncodingString:_text];
+}
+
+- (NSString *)abid {
+    return [self stringByEncodingString:_abid];
+}
+
+- (NSString *)stringByEncodingString:(NSString *)string {
+    CFStringRef encodedString = CFURLCreateStringByAddingPercentEscapes(NULL, (CFStringRef)string, NULL,
+                                                                        (CFStringRef)@"!*'();:@&=+$,/?%#[]", kCFStringEncodingUTF8);
+    return CFBridgingRelease(encodedString);
 }
 
 @end


### PR DESCRIPTION
The `NSString` method `stringByAddingPercentEscapesUsingEncoding:` does not escape `?` and `&`, so any text sent to Whatsapp with those characters in the `text` parameter will fail. 
